### PR TITLE
Fix private import error in downstream packages with strict type checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Internal change: Switched project management from hatch to uv.
 
+### Fixed
+
+- Fix private import type error for downstream packages with strict type checks.
+
 ## [0.1.1] - 2025-04-11
 
 ### Fixed

--- a/src/muuttaa/__init__.py
+++ b/src/muuttaa/__init__.py
@@ -6,3 +6,11 @@ from muuttaa.core import (
     Projector,  # noqa: F401
     project,  # noqa: F401
 )
+
+__all__ = [
+    "TransformationStrategy",
+    "SegmentWeights",
+    "apply_transformations",
+    "Projector",
+    "project",
+]


### PR DESCRIPTION
Adds an `__all__` to __init__.py at package root with explicit exports. This is so downstream users don't get dinged for Private Import Usage by strict type checkers.